### PR TITLE
fix the mismatch nested_kernel_entrance_counter add/sub bug

### DIFF
--- a/machines/cortex-a/tpl_system_call.S
+++ b/machines/cortex-a/tpl_system_call.S
@@ -237,11 +237,6 @@ flush_pipeline:
    ********************************************/
 invalid_service_id:  /* currently, if invalid service id is specified, we do nothing */
 swi_no_context_switch_exit:
-  /* manage reentrance of kernel */
-  ldr r3, =nested_kernel_entrance_counter
-  ldr r2, [r3]
-  sub r2, r2, #1
-  str r2, [r3]
 
 #if WITH_MEMORY_PROTECTION == YES
   /* in case we enter in trusted function, we must prepare
@@ -253,6 +248,12 @@ swi_no_context_switch_exit:
 #endif /* WITH_MEMORY_PROTECTION == YES */
 
 swi_skip_kernel_exit:
+  /* manage reentrance of kernel */
+  ldr r3, =nested_kernel_entrance_counter
+  ldr r2, [r3]
+  sub r2, r2, #1
+  str r2, [r3]
+
   /* pops the kernel enter stack frame */
   ldmfd sp!, {r3}
   msr spsr, r3


### PR DESCRIPTION
This happens that a SWI CALL during IRQ, for example an ALARMCALLBACK call API ActivateTask,
I think an ActivateTask...etc API should be allowed to be called in ALARMCALLBACK.

And I have done a porting of trampoline to bcm2835 qemu-rpi I directly download from https://github.com/idrawone/qemu-rpi/raw/master/tools/qemu-system-arm-rpi_UART1.tar.gz, and integrated to my as(https://github.com/parai/as) repo ascore release(make 41 & make 42), and then use qemu& gdb to debug the trampoline os.

Signed-off-by: Parai Wang <parai@foxmail.com>