### PR TITLE
Fix for issue #61

### DIFF
--- a/machines/cortex-a/tpl_machine_arm.c
+++ b/machines/cortex-a/tpl_machine_arm.c
@@ -152,8 +152,15 @@ void tpl_disable_interrupts(void)
 
 }
 
-void tpl_os_disable_interrupts(void) {}
-void tpl_os_enable_interrupts(void) {}
+void tpl_disable_os_interrupts(void)
+{
+  tpl_disable_interrupts();
+}
+
+void tpl_enable_os_interrupts(void)
+{
+  tpl_enable_interrupts();
+}
 
 /*
  * tpl_init_context initialize a context to prepare a task to run.


### PR DESCRIPTION
I simply renamed the function and added a call to the old enable/disable interrupts functions. This doesn't change the behaviour of anything since ` tpl_resume_os_interrupts_service` used to call `tpl_enable_interrupts` directly.