### PR TITLE
copy paste error in masking lower ISR2 interrupts

### DIFF
--- a/os/tpl_os_kernel.c
+++ b/os/tpl_os_kernel.c
@@ -665,7 +665,7 @@ FUNC(P2CONST(tpl_context, AUTOMATIC, OS_CONST), OS_CODE)
   }
 
   /* if the elected process is an ISR2, mask lower ISR2 interrupts */
-  if (TPL_KERN_REF(kern).s_running->type == IS_ROUTINE)
+  if (TPL_KERN_REF(kern).s_elected->type == IS_ROUTINE)
   {
     tpl_mask_isr2_priority(TPL_KERN_REF(kern).elected_id);
   }


### PR DESCRIPTION
I had the problem that when sending a message from a ISR2 the kernel has crashed. This was caused by an index out of bounds in the function tpl_mask_isr2_priority. The result of the index calculation was negative, so the resulting function call has crashed the system. 

I first fixed it with an boundary check (maybe usefull at all?) but now I think it is a copy and paste error in line 668 of tpl_os_kernel.c. 

The line is if `(TPL_KERN_REF(kern).s_running->type == IS_ROUTINE)` but it should be if `(TPL_KERN_REF(kern).s_elected->type == IS_ROUTINE)`.

The platform was STM32F407. 