### PR TITLE
Linking against the wrong library version newlib

### DIFF
--- a/goil/templates/config/cortex/armv7em/buildOptions.oil
+++ b/goil/templates/config/cortex/armv7em/buildOptions.oil
@@ -15,7 +15,7 @@ CPU buildOptions {
     COMMONFLAGS = "-Wmissing-field-initializers"; // Struct initialized with incorrect number of fiels
     COMMONFLAGS = "-mcpu=cortex-m4";              // Compile for cortex-m4
     COMMONFLAGS = "-mthumb";                      // Thumb instruction set
-    COMMONFLAGS = "-mfloat-abi=soft";             // Floating point numbers are computed in software
+    COMMONFLAGS = "-mfloat-abi=softfp";           // Floating point numbers are computed in software
     COMMONFLAGS = "-mfpu=fpv4-sp-d16";            // Truly obscure option to set. Check http://stackoverflow.com/questions/19464556/how-to-link-gcc-options-to-the-arm-mcu-fpu-datasheet
     COMMONFLAGS = "-nostartfiles";                // Default startfiles (crt0.c) are not used
     COMMONFLAGS = "-fno-builtin";                 // Do not used built in gcc functions


### PR DESCRIPTION
In build.py gcc with the option "-print-file-name=libXX" is used to get the right library libc/libgcc for linking. This command is running with the parameter -mfloat-abi=soft and -mfpu=fpv4-sp-d16, which is an invalid configuration for gcc and it is returning the default library (./arm-none-eabi/lib/libc.a). When you change the mfloat-abi to softfp the right library (./arm-none-eabi/lib/thumb/libc.a) is returned and all the functions from newlib are working properly.

This problem was detected by trying to get printf to work and getting strange behavior and bad looking disassembly while debugging it. It was reproduced with 6-2017-q1-update and 6-2017-q2-update of arm-none-eabi