### PR TITLE
[doc] Fix headers misrendering

### DIFF
--- a/examples/avr/README.md
+++ b/examples/avr/README.md
@@ -1,10 +1,10 @@
-#Trampoline examples for AVR8 Targets
+# Trampoline examples for AVR8 Targets
 
 This directory shows some examples for 8 bits AVR targets, including some Arduino boards.
 For all these examples, the Gcc cross-compiler is required.
 
 # Installation 
-##avr-gcc cross-compiler
+## avr-gcc cross-compiler
 **Linux** (Debian/Ubuntu) -> `sudo apt-get install avr-libc gcc-avr avrdude`
 
 **MacOSX**  -> [AVR CrossPack](http://www.obdev.at/products/crosspack/download.html)
@@ -24,7 +24,7 @@ git submodule update machines/avr/arduino
 
 It gets the trampoline patched version of ArduinoCore-avr from [GitHub](https://github.com/TrampolineRTOS/ArduinoCore-avr.git).
 
-##Compilation
+## Compilation
 The build script is written in Python (2.7 and 3.x) and works for Windows, Mac and Linux. The build script (make.py) is generated from goil the first time goil is called.
 
 See examples, for the correct first call to goil (in runGoil.bat for Windows).

--- a/examples/avr/arduinoMega2560/README.md
+++ b/examples/avr/arduinoMega2560/README.md
@@ -4,7 +4,7 @@ The main difference with the core of ATMega328p (Arduino Uno) is that the progra
 
 ***Be sure that Arduino related libraries are installed: see [README.md](../README.md) in parent folder***
 
-#first run
+# first run
 In the first run, the `goil` compiler will generate:
 
 * a python build script `make.py` (to build everything)
@@ -14,7 +14,7 @@ If `file.oil` is the main `oil` file, and `TRAMPOLINE_ROOT` is the path to the r
 
 `$goil --target=avr/arduino/uno --templates=$TRAMPOLINE_ROOT/goil/templates/ file.oil`
 
-#Build
+# Build
 The commands builds the binary file (both the `.elf` and `.hex` files).
 
 `$./make.py`
@@ -23,7 +23,7 @@ The commands builds the binary file (both the `.elf` and `.hex` files).
 
 in case of problem, you may need to run `./make.py -j 1` to have the full compilation line.
 
-#flash
+# flash
 
 The avrdude port should be set as en environmemnt variable. Then, the build script can call avrdude to flash the Arduino:
 

--- a/examples/avr/arduinoUno/README.md
+++ b/examples/avr/arduinoUno/README.md
@@ -3,7 +3,7 @@ AVR sample projects Arduino Uno boards (ATMega328P)
 ***Be sure that Arduino related libraries are installed: see [README.md](../README.md) in parent folder***
 
 
-#first run
+# first run
 In the first run, the `goil` compiler will generate:
 
 * a python build script `make.py` (to build everything)
@@ -14,7 +14,7 @@ If `file.oil` is the main `oil` file, and `TRAMPOLINE_ROOT` is the path to the r
 `$goil --target=avr/arduino/uno --templates=$TRAMPOLINE_ROOT/goil/templates/ file.oil`
 
 
-#Build
+# Build
 The commands builds the binary file (both the `.elf` and `.hex` files).
 
 `$./make.py`
@@ -23,7 +23,7 @@ The commands builds the binary file (both the `.elf` and `.hex` files).
 
 in case of problem, you may need to run `./make.py -j 1` to have the full compilation line.
 
-#flash
+# flash
 
 The avrdude port should be set as en environmemnt variable. Then, the build script can call avrdude to flash the Arduino:
 

--- a/examples/posix/README.md
+++ b/examples/posix/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for Posix Targets
+# Trampoline examples for Posix Targets
 
 This directory shows some examples for the POSIX target. The Posix target run Trampoline inside a Unix process. 
 
@@ -6,7 +6,7 @@ To simulate the environment, another process runs ViPER (Virtual Processor Emula
 
 More information is available on this (not really up-to-date) [publication](http://trampoline.rts-software.org/IMG/pdf/trampoline.pdf) at 11th International Conference on Emerging Technologies and Factory Automation (ETFA'06) (in particular, see section 6.2 and figure 4)
 
-##Building ViPER
+## Building ViPER
 on UNIX shell:
 
     $ cd viper
@@ -17,7 +17,7 @@ It is recommended to get the path to ViPER in the environment variables, and def
 
     $ export VIPER_PATH=PATH_TO_TRAMPOLINE/viper
 
-##Run example
+## Run example
 Examples are easy to run:
 The first time, goil should be called directly. It will generate the appropriate Makefile:
 

--- a/examples/ppc/multicore/blink_1c/README.md
+++ b/examples/ppc/multicore/blink_1c/README.md
@@ -1,10 +1,10 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a simple blink example, tested and working for MPC5643L target using
 Cosmic Software compiler. An alarm wakes up a task which will turn on/off the
 led.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -15,7 +15,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -26,7 +26,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/blink_1c_withOrti/README.md
+++ b/examples/ppc/multicore/blink_1c_withOrti/README.md
@@ -1,10 +1,10 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a simple blink example, tested and working for MPC5643L target using
 Cosmic Software compiler. An alarm wakes up a task which will turn on/off the
 led.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -15,7 +15,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -26,7 +26,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/blink_2c/README.md
+++ b/examples/ppc/multicore/blink_2c/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a dualcore blink example, tested and working for MPC5643L target using
 Cosmic Software compiler.
@@ -7,7 +7,7 @@ This example uses two synchronized cores, with one task and one alarm per core.
 When an alarm is triggered, the core to whose it belongs activates the task of
 the other core and ask for a context switch through an intercore interruption.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -18,7 +18,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -29,7 +29,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/blink_2c_arxml/README.md
+++ b/examples/ppc/multicore/blink_2c_arxml/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a dualcore blink example, tested and working for MPC5643L target using
 Cosmic Software compiler.
@@ -12,7 +12,7 @@ This is the arxml version of the example blink_2c.
 You can use the option --arxmlPrintOil to display the oil version of the arxml
 file.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -23,7 +23,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -34,7 +34,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/blink_2c_optim/README.md
+++ b/examples/ppc/multicore/blink_2c_optim/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a dualcore blink example, tested and working for MPC5643L target using
 Cosmic Software compiler.
@@ -7,7 +7,7 @@ This example uses two synchronized cores, with one task and one alarm per core.
 When an alarm is triggered, the core to whose it belongs activates the task of
 the other core and ask for a context switch through an intercore interruption.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -19,7 +19,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -30,7 +30,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/buttons_2c/README.md
+++ b/examples/ppc/multicore/buttons_2c/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a dualcore timing protection example, tested and working for MPC5643L
 target using Cosmic Software compiler.
@@ -19,7 +19,7 @@ task and one watchdog per core :
 
 Both leds 1 and 2 are resetted by the ProtectionHook, called by the watchdog.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -30,7 +30,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 blink.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -41,7 +41,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32

--- a/examples/ppc/multicore/spinlocks/README.md
+++ b/examples/ppc/multicore/spinlocks/README.md
@@ -1,4 +1,4 @@
-#Trampoline examples for PowerPC target
+# Trampoline examples for PowerPC target
 
 This is a dualcore blink example, tested and working for MPC5643L target using
 Cosmic Software compiler.
@@ -13,7 +13,7 @@ shared_1 and shared_2.
 - The led 0 lights on when shared_1 has reached its maximum.
 - The led 1 lights on when shared_2 has reached its maximum.
 
-##How to build the example
+## How to build the example
 To compile the example, one can use the bash script "run.sh" in this directory.
 The -c option cleans the directory from outputs and generated files.
 The -g option generate C files using goil.
@@ -24,7 +24,7 @@ The -l option sets the compilation as to be done locally.
 The -a option does everything (except setting the compilation as local, so one
 needs to use ./run.sh -al if its wants to do everything locally).
 
-##Using Cosmic Software tools
+## Using Cosmic Software tools
 The build process uses Cosmic Software's compilation tools (property set in
 spinlock.oil file). The call of these tools are made by the cxvle_auto.py and
 clnk_auto.py python scripts located in ../../tools directory. These scripts, by
@@ -35,7 +35,7 @@ one can set the environment variables COSMIC_CXPPC, COSMIC_CAPPC, COSMIC_CPPPC,
 COSMIC_CLNK and COSMIC_CVDWARF to use these commands instead (so something like
 'export COSMIC_CXPPC="wine ~/path/to/cosmic/tools/cxvle.exe"').
 
-##Execute the program through T32 (Lauterbach)
+## Execute the program through T32 (Lauterbach)
 
 SH $  : Command in shell
 T32 & : Command in T32


### PR DESCRIPTION
Headers in markdown files were not being correctly rendered.
The markdown format requires a space between the header mark and its content:
```
# Header
```