### PR TITLE
[viper] Fixing linking error on GCC 10 due to the "-fno-common" flag which is now the default

### DIFF
--- a/viper/Makefile
+++ b/viper/Makefile
@@ -18,6 +18,7 @@
 #arch may be either LINUX or DARWIN (MacOsX) at this time.
 ARCH = $(shell uname -s)
 SRCS= com.c exec.c log.c main.c timer.c control.c
+CFLAGS += -fcommon
 
 ########################################################
 # ARCH dependant stuff


### PR DESCRIPTION
On GCC 10 the `-fno-common` is now [the default](https://gcc.gnu.org/gcc-10/changes.html).
> GCC now defaults to -fno-common. As a result, global variable accesses are more efficient on various targets. In C, global variables with multiple tentative definitions now result in linker errors. With -fcommon such definitions are silently merged during linking.

So now viper fail to be linked :
```
cc -o viper .obj/com.o .obj/exec.o .obj/log.o .obj/main.o .obj/timer.o .obj/control.o -lpthread -lrt 
/usr/sbin/ld : .obj/control.o:(.bss+0x10) : définitions multiples de « osek_app_pid »; .obj/com.o:(.bss+0x8) : défini pour la première fois ici
collect2: erreur: ld a retourné le statut de sortie 1
make: *** [Makefile:46 : viper] Erreur 1
```

This pull request insert the `-fcommon` compile flag to resolve this problem.