### PR TITLE
Adding TerminateTask(); in the examples provided

### DIFF
--- a/examples/avr/arduinoMega2560/blink/blink.cpp
+++ b/examples/avr/arduinoMega2560/blink/blink.cpp
@@ -20,5 +20,6 @@ TASK(periodicTask)
 	nb++;
 	if(nb & 1) digitalWrite(13, HIGH); //odd
 	else digitalWrite(13, LOW);        //even
+	TerminateTask();
 }
 

--- a/examples/avr/arduinoMega2560/extInterrupt/extInterrupt.cpp
+++ b/examples/avr/arduinoMega2560/extInterrupt/extInterrupt.cpp
@@ -49,4 +49,5 @@ TASK(periodicTask)
 	static unsigned int state = LOW;
 	digitalWrite(13,state);
 	state = !state;
+	TerminateTask();
 }

--- a/examples/avr/arduinoMega2560/serial/serial.cpp
+++ b/examples/avr/arduinoMega2560/serial/serial.cpp
@@ -24,4 +24,5 @@ TASK(periodicTask)
 
 	Serial.print(nb);
 	Serial.println(" done");
+	TerminateTask();
 }

--- a/examples/avr/arduinoUno/blink/blink.cpp
+++ b/examples/avr/arduinoUno/blink/blink.cpp
@@ -20,5 +20,6 @@ TASK(periodicTask)
 	nb++;
 	if(nb & 1) digitalWrite(13, HIGH); //odd
 	else digitalWrite(13, LOW);        //even
+	TerminateTask();
 }
 

--- a/examples/avr/arduinoUno/customCounterExample/counter.cpp
+++ b/examples/avr/arduinoUno/customCounterExample/counter.cpp
@@ -40,4 +40,5 @@ TASK(periodicTask)
     digitalWrite(13, HIGH); // odd
   else
     digitalWrite(13, LOW); // even
+  TerminateTask();
 }

--- a/examples/avr/arduinoUno/extInterrupt/extInterrupt.cpp
+++ b/examples/avr/arduinoUno/extInterrupt/extInterrupt.cpp
@@ -53,4 +53,5 @@ TASK(periodicTask)
 	static unsigned int state = LOW;
 	digitalWrite(13,state);
 	state = !state;
+	TerminateTask();
 }

--- a/examples/avr/arduinoUno/serial/serial.cpp
+++ b/examples/avr/arduinoUno/serial/serial.cpp
@@ -24,4 +24,5 @@ TASK(periodicTask)
 
 	Serial.print(nb);
 	Serial.println(" done");
+	TerminateTask();
 }

--- a/examples/avr/arduinoUno/trace/trace.cpp
+++ b/examples/avr/arduinoUno/trace/trace.cpp
@@ -20,4 +20,5 @@ TASK(periodicTask)
 	nb++;
 	if(nb & 1) digitalWrite(13, HIGH); //odd
 	else digitalWrite(13, LOW);        //even
+	TerminateTask();
 }


### PR DESCRIPTION
This is a minor thing, but I added at the end of each task in the examples provided for Arduinos a simple "TerminateTask();". 
Arduino manages to still run without this code even if it is not beautiful, but this is enforcing a bad programming habit.

This is something similar as "fclose" for files.

**Codes were tested and were running like expected. Just it drives better new programmers.**