### PR TITLE
goil: Ignored the 'goil-debug' binary when Goil is built for Linux.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 *~
-#goil compiler
-goil/makefile-unix/goil
 # temporary directory to compile all examples.
 tmpExamplesCompilation
 ## Vim...

--- a/goil/makefile-unix/.gitignore
+++ b/goil/makefile-unix/.gitignore
@@ -1,0 +1,2 @@
+goil
+goil-debug


### PR DESCRIPTION
Without this change, running the `git status` command would show the `goil-debug` binary like below :
```
Fichiers non suivis:
  (utilisez "git add <fichier>..." pour inclure dans ce qui sera validé)
        goil/makefile-unix/goil-debug
```