### PR TITLE
Add initial GitHub ci

### DIFF
--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -1,0 +1,24 @@
+name: Build compiler and examples
+on: [push, pull_request]
+env:
+  # Create a new and unique cache for each run, otherwise the cache from the previous actions would be used
+  CACHE_KEY: repo-${{ github.run_id }}
+
+jobs:
+  goil:
+    name: Build Goil compiler
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build Goil
+        run: ./build.py
+        working-directory: goil/makefile-unix
+      - name: Cache Goil build
+        # Cache the source and build files to share them later with other jobs
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -48,3 +48,28 @@ jobs:
       - name: Build the code
         run: ./build.py
         working-directory: examples/cortex-a/armv7/bcm2836/rpi2/${{ matrix.example_name }}
+
+  avr-arduino-uno-examples:
+    name: Build AVR Arduino Uno examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        example_name: [blink, customCounterExample, extInterrupt, serial, trace]
+    steps:
+      - name: Install AVR toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y avr-libc gcc-avr
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        # Use a wildcard to find the .oil file because it is not always named the same than the directory is it contained by
+        run: ${{ env.GOIL }} --target=avr/arduino/uno --templates=../../../../goil/templates/ *.oil
+        working-directory: examples/avr/arduinoUno/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./build.py
+        working-directory: examples/avr/arduinoUno/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -73,3 +73,27 @@ jobs:
       - name: Build the code
         run: ./build.py
         working-directory: examples/avr/arduinoUno/${{ matrix.example_name }}
+
+  avr-arduino-mega-2560-examples:
+    name: Build AVR Arduino Mega 2560 examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        example_name: [blink, extInterrupt, serial]
+    steps:
+      - name: Install AVR toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y avr-libc gcc-avr
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=avr/arduino/mega --templates=../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/avr/arduinoMega2560/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./build.py
+        working-directory: examples/avr/arduinoMega2560/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   # Create a new and unique cache for each run, otherwise the cache from the previous actions would be used
   CACHE_KEY: repo-${{ github.run_id }}
+  GOIL: ${{ github.workspace }}/goil/makefile-unix/goil
 
 jobs:
   goil:
@@ -22,3 +23,28 @@ jobs:
         with:
           path: ${{ github.workspace }}
           key: ${{ env.CACHE_KEY }}
+
+  raspberry-pi-examples:
+    name: Build Raspberry Pi examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        # List only the examples that currently compile
+        example_name: [blink]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex-a/armv7/bcm2836/rpi2 --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex-a/armv7/bcm2836/rpi2/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./build.py
+        working-directory: examples/cortex-a/armv7/bcm2836/rpi2/${{ matrix.example_name }}


### PR DESCRIPTION
This GitHub CI builds Goil then several examples from AVR and Raspberry Pi machines. The purpose is to make sure that the build is not broken when new commits are added.
The CI is extensible and new tests can be added when needed.