### PR TITLE
Add initial CAN stack and example

### DIFF
--- a/com/ComStack_Types.h
+++ b/com/ComStack_Types.h
@@ -1,0 +1,65 @@
+/**
+ * @file ComStack_Types.h
+ *
+ * @section desc File description
+ *
+ * This implementation is based on AUTOSAR CAN Driver R22-11, see
+ * https://www.autosar.org/fileadmin/standards/R22-11/CP/AUTOSAR_SWS_CommunicationStackTypes.pdf
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#ifndef COM_STACK_TYPES_H
+#define COM_STACK_TYPES_H
+
+#include <tpl_os_types.h>
+
+/**
+ * @typedef PduIdType
+ *
+ * Variables of this type serve as a unique identifier of a PDU within a
+ * software module or a set thereof, and also for interaction of two software
+ * modules where the PduId of the corresponding target module is being used for
+ * referencing.
+ */
+typedef uint8 PduIdType;
+
+/**
+ * @typedef PduLengthType
+ *
+ * Variables of this type serve as length information of a PDU. The length
+ * information is provided in number of bytes.
+ */
+typedef uint32 PduLengthType;
+
+/**
+ * @typedef PduInfoType
+ *
+ * Variables of this type shall be used to store the basic information about a
+ * PDU of any type, namely a pointer variable pointing to its SDU (payload), a
+ * pointer to Meta Data of the PDU, and the corresponding length of the SDU in
+ * bytes.
+ */
+typedef struct
+{
+	uint8 *SduDataPtr;
+	uint8 *MetaDataPtr;
+	PduLengthType SduLength;
+} PduInfoType;
+
+#endif

--- a/examples/posix/can_demo/.gitignore
+++ b/examples/posix/can_demo/.gitignore
@@ -1,0 +1,3 @@
+can_demo/
+can_demo_exe
+*.py

--- a/examples/posix/can_demo/README.md
+++ b/examples/posix/can_demo/README.md
@@ -1,0 +1,26 @@
+# Trampoline CAN demo example
+
+Have a look to ../README.md for more information about the POSIX target (using ViPER).
+
+This example allows to test the Trampoline CAN stack on the development PC.
+
+On Linux:
+```
+goil --target=posix/linux  --templates=../../../goil/templates/ can_demo.oil
+```
+
+Then, the makefile is generated, and it will call goil again when the .oil file
+is updated.
+```
+./make.py
+```
+
+Then, run the trampoline binary.
+```
+VIPER_PATH=../../../viper/ ./can_demo_exe
+```
+
+To quit, run the command below from another terminal.
+```
+killall -SIGINT can_demo_exe
+```

--- a/examples/posix/can_demo/can_demo.c
+++ b/examples/posix/can_demo/can_demo.c
@@ -1,0 +1,79 @@
+#include <Can.h>
+#include <CanIf.h>
+#include <stdio.h>
+#include <string.h>
+#include <tpl_can_demo_driver.h>
+#include <tpl_os.h>
+
+int main(void)
+{
+	// Statically list the CAN controllers to use in the application
+	static tpl_can_controller_t *can_controllers[] =
+	{
+		&can_demo_driver_controller_1,
+		&can_demo_driver_controller_2,
+		NULL
+	};
+	static Can_ConfigType can_config_type =
+	{
+		can_controllers
+	};
+	int ret;
+
+	printf("Initializing all requested controllers...\r\n");
+	ret = Can_Init(&can_config_type);
+	if (ret)
+	{
+		printf("[%s:%d] Error : Can_Init() failed (%d).\r\n", __func__, __LINE__, ret);
+		return -1;
+	}
+
+	printf("Setting first controller baud rate...\r\n");
+	ret = CanIf_SetBaudrate(0, CAN_BAUD_RATE_500_KBPS);
+	if (ret)
+	{
+		printf("[%s:%d] Error : CanIf_SetBaudrate() failed (%d).\r\n", __func__, __LINE__, ret);
+		return -1;
+	}
+
+	StartOS(OSDEFAULTAPPMODE);
+	return 0;
+}
+
+TASK(can_task)
+{
+	Std_ReturnType ret;
+	uint8 payload[8];
+	Can_PduType can_pdu, *pointer_can_pdu;
+	PduInfoType pdu_info;
+	int i;
+
+	printf("Transmitting a CAN 2.0 frame with standard ID...\r\n");
+	can_pdu.id = 0x123 | TPL_CAN_ID_TYPE_STANDARD;
+	strcpy(payload, "Ciao !");
+	can_pdu.length = strlen(payload);
+	can_pdu.sdu = payload;
+	pdu_info.SduDataPtr = (uint8 *) &can_pdu;
+	pdu_info.SduLength = sizeof(can_pdu);
+	ret = CanIf_Transmit(0, &pdu_info);
+	if (ret)
+		printf("[%s:%d] Error : failed to transmit the frame (%d).\r\n", __func__, __LINE__, ret);
+	printf("Transmission succeeded.\r\n");
+
+	printf("Waiting for a CAN 2.0 frame with standard ID...\r\n");
+	ret = CanIf_ReadRxPduData(0, &pdu_info);
+	if (ret)
+		printf("No frame is available.\r\n");
+	else
+	{
+		printf("A frame has been received.\r\n");
+
+		pointer_can_pdu = (Can_PduType *) pdu_info.SduDataPtr;
+		printf("ID = 0x%X, length = %d, payload = ", pointer_can_pdu->id, pointer_can_pdu->length);
+		for (i = 0; i < pointer_can_pdu->length; i++)
+			printf("0x%02X ", pointer_can_pdu->sdu[i]);
+		printf("\r\n");
+	}
+
+	TerminateTask();
+}

--- a/examples/posix/can_demo/can_demo.oil
+++ b/examples/posix/can_demo/can_demo.oil
@@ -1,0 +1,27 @@
+OIL_VERSION = "2.5";
+
+CPU can_task {
+	OS config {
+		STATUS = EXTENDED;
+		BUILD = TRUE {
+			APP_SRC = "can_demo.c";
+			TRAMPOLINE_BASE_PATH = "../../..";
+			LDFLAGS = "-lrt -lpthread";
+			APP_NAME = "can_demo_exe";
+			LINKER = "gcc";
+			SYSTEM = PYTHON;
+			LIBRARY = can;
+		};
+	};
+  
+	APPMODE stdAppmode {};
+
+	TASK can_task {
+		PRIORITY = 1;
+		AUTOSTART = TRUE {
+			APPMODE = stdAppmode;
+		};
+		ACTIVATION = 1;
+		SCHEDULE = FULL;
+	};
+};

--- a/goil/templates/build/build_py.goilTemplate
+++ b/goil/templates/build/build_py.goilTemplate
@@ -209,6 +209,7 @@ end foreach
 %
 if with_ioc:
   includeDirs += ["-I", "% !OS::BUILD_S::TRAMPOLINE_BASE_PATH %/ioc"]
+includeDirs += ["-I", "% !OS::BUILD_S::TRAMPOLINE_BASE_PATH %/com"]
 includeDirs += ["-I", "% !OS::BUILD_S::TRAMPOLINE_BASE_PATH %/os"]
 includeDirs += ["-I", "% !OS::BUILD_S::TRAMPOLINE_BASE_PATH %/debug"]
 includeDirs += ["-I", "% !PROJECT %"]

--- a/goil/templates/config/posix/config.oil
+++ b/goil/templates/config/posix/config.oil
@@ -13,6 +13,9 @@ IMPLEMENTATION posix {
         STRING COMPILER = "gcc";
         STRING ASSEMBLER = "gcc";
         STRING LINKER = "gcc";
+        ENUM [
+          can
+        ] LIBRARY[];
       },
       FALSE
     ] BUILD = FALSE;
@@ -62,5 +65,10 @@ CPU posix {
     PATH = "../viper";
   };
 
+  LIBRARY can {
+    PATH = "../net/can";
+    CFILE = "tpl_can_core.c";
+    CFILE = "../../machines/posix/tpl_can_demo_driver.c";
+  };
 };
 

--- a/machines/posix/tpl_can_demo_driver.c
+++ b/machines/posix/tpl_can_demo_driver.c
@@ -1,0 +1,117 @@
+/**
+ * @file tpl_can_demo_driver.c
+ *
+ * @section desc File description
+ *
+ * See tpl_can_demo_driver.h for description.
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#include <Can.h>
+#include <stdio.h>
+#include <string.h>
+#include <tpl_can_demo_driver.h>
+
+static int can_demo_driver_init(struct tpl_can_controller_t *ctrl, void *data);
+static int can_demo_driver_set_baudrate(struct tpl_can_controller_t *ctrl, tpl_can_baud_rate_t baud_rate);
+static Std_ReturnType can_demo_driver_transmit(struct tpl_can_controller_t *ctrl, const Can_PduType *pdu_info);
+static Std_ReturnType can_demo_driver_receive(struct tpl_can_controller_t *ctrl, Can_PduType *pdu_info);
+static int can_demo_driver_is_data_available(struct tpl_can_controller_t *ctrl);
+
+tpl_can_controller_t can_demo_driver_controller_1 =
+{
+	0x12341111,
+	can_demo_driver_init,
+	can_demo_driver_set_baudrate,
+	can_demo_driver_transmit,
+	can_demo_driver_receive,
+	can_demo_driver_is_data_available
+};
+
+tpl_can_controller_t can_demo_driver_controller_2 =
+{
+	0x12342222,
+	can_demo_driver_init,
+	can_demo_driver_set_baudrate,
+	can_demo_driver_transmit,
+	can_demo_driver_receive,
+	can_demo_driver_is_data_available
+};
+
+static int can_demo_driver_init(struct tpl_can_controller_t *ctrl, void *data)
+{
+	printf("[%s:%d] Initialized controller 0x%08X.\r\n", __func__, __LINE__, ctrl->base_address);
+	return 0;
+}
+
+static int can_demo_driver_set_baudrate(struct tpl_can_controller_t *ctrl, tpl_can_baud_rate_t baud_rate)
+{
+	static uint32 baud_rate_lut[] =
+	{
+		// CAN_BAUD_RATE_50_KBPS
+		50000,
+		// CAN_BAUD_RATE_100_KBPS
+		100000,
+		// CAN_BAUD_RATE_125_KBPS
+		125000,
+		// CAN_BAUD_RATE_250_KBPS
+		250000,
+		// CAN_BAUD_RATE_500_KBPS
+		500000,
+		// CAN_BAUD_RATE_1_MBPS
+		1000000
+	};
+	uint32 bits_per_second;
+
+	if (baud_rate >= CAN_BAUD_RATE_COUNT)
+	{
+		printf("[%s:%d] Wrong baud rate code %d, aborting.\r\n", baud_rate);
+		return -1;
+	}
+	bits_per_second = baud_rate_lut[baud_rate];
+
+	printf("[%s:%d] Baud rate set to %u for controller 0x%08X.\r\n", __func__, __LINE__, bits_per_second, ctrl->base_address);
+	return 0;
+}
+
+static Std_ReturnType can_demo_driver_transmit(struct tpl_can_controller_t *ctrl, const Can_PduType *pdu_info)
+{
+	uint32 i;
+
+	printf("[%s:%d] Transmission request for controller 0x%08X, CAN ID = 0x%X, flags = 0x%02X, payload length = %u, payload = ",
+		   __func__, __LINE__, ctrl->base_address, pdu_info->id & ~TPL_CAN_ID_TYPE_MASK, pdu_info->length, pdu_info->id >> 30);
+	for (i = 0; i < pdu_info->length; i++)
+		printf("0x%02X ", pdu_info->sdu[i]);
+	printf("\r\n");
+
+	return 0;
+}
+
+static Std_ReturnType can_demo_driver_receive(struct tpl_can_controller_t *ctrl, Can_PduType *pdu_info)
+{
+	pdu_info->id = 0x1ab; // Random value
+	strcpy(pdu_info->sdu, "Test");
+	pdu_info->length = strlen(pdu_info->sdu);
+	return 0;
+}
+
+static int can_demo_driver_is_data_available(struct tpl_can_controller_t *ctrl)
+{
+	return 1;
+}

--- a/machines/posix/tpl_can_demo_driver.h
+++ b/machines/posix/tpl_can_demo_driver.h
@@ -1,0 +1,37 @@
+/**
+ * @file tpl_can_demo_driver.h
+ *
+ * @section desc File description
+ *
+ * Exposes two dummy CAN controllers that implements all controller operations
+ * by displaying debug messages.
+ * The purpose of this driver is to test the CAN stack.
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#ifndef TPL_CAN_DEMO_DRIVER_H
+#define TPL_CAN_DEMO_DRIVER_H
+
+#include <Can.h>
+
+// All available controllers
+extern tpl_can_controller_t can_demo_driver_controller_1;
+extern tpl_can_controller_t can_demo_driver_controller_2;
+
+#endif

--- a/net/can/Can.h
+++ b/net/can/Can.h
@@ -1,0 +1,91 @@
+/**
+ * @file Can.h
+ *
+ * @section desc File description
+ *
+ * This implementation is based on AUTOSAR CAN Driver R22-11, see
+ * https://www.autosar.org/fileadmin/standards/R21-11/CP/AUTOSAR_SWS_CANDriver.pdf
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#ifndef CAN_H
+#define CAN_H
+
+#include <Can_GeneralTypes.h>
+#include <ComStack_Types.h>
+
+/**
+ * @typedef Can_ConfigType
+ *
+ * Contain a static list of all controllers to configure.
+ * The provided variable must be reachable during all the application lifetime.
+ */
+typedef struct
+{
+	tpl_can_controller_t **controllers_list;
+} Can_ConfigType;
+
+/**
+ * This function initializes the module.
+ *
+ * @param Config Pointer to driver configuration. All the pointed memory must
+ * be reachable during all the application lifetime.
+ *
+ * @retval 0 if the function succeeded.
+ * @retval -5 if a driver callback function is missing.
+ *
+ * @note Can_Init() return type is void in AUTOSAR standard. Returning void here
+ * would involve to implement higher AUTOSAR CAN stack layers, which is too
+ * complex for the current usage.
+ */
+int Can_Init(const Can_ConfigType *Config);
+
+/**
+ * This service shall set the baud rate configuration of the CAN controller.
+ * Depending on necessary baud rate modifications the controller might have to
+ * reset.
+ *
+ * @param Controller CAN controller, whose baud rate shall be set. Here it is
+ * the index of the controller in the controllers list provided to Can_Init().
+ * @param BaudRateConfigID References a baud rate configuration by ID.
+ *
+ * @retval E_OK Service request accepted, setting of (new) baud rate started.
+ * @retval E_NOT_OK Service request not accepted.
+ */
+Std_ReturnType Can_SetBaudrate(uint8 Controller, uint16 BaudRateConfigID);
+
+/**
+ * This function is called by CanIf to pass a CAN message to CanDrv for
+ * transmission.
+ *
+ * @param Hth Information which HW-transmit handle shall be used for transmit.
+ * Implicitly this is also the information about the controller to use because
+ * the Hth numbers are unique inside one hardware unit.
+ * Here it is the index of the controller in the controllers list provided to
+ * Can_Init().
+ * @param PduInfo Pointer to SDU user memory, Data Length and Identifier.
+ *
+ * @retval E_OK Write command has been accepted.
+ * @retval E_NOT_OK Development error occurred.
+ * @retval CAN_BUSY No TX hardware buffer available or pre-emptive call of
+ * Can_Write that can't be implemented re-entrant (see Can_ReturnType).
+ */
+Std_ReturnType Can_Write(Can_HwHandleType Hth, const Can_PduType *PduInfo);
+
+#endif

--- a/net/can/CanIf.h
+++ b/net/can/CanIf.h
@@ -1,0 +1,87 @@
+/**
+ * @file CanIf.h
+ *
+ * @section desc File description
+ *
+ * This implementation is based on AUTOSAR CAN Driver R22-11, see
+ * https://www.autosar.org/fileadmin/standards/R21-11/CP/AUTOSAR_SWS_CANInterface.pdf
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#ifndef CAN_IF_H
+#define CAN_IF_H
+
+#include <ComStack_Types.h>
+#include <tpl_os_types.h>
+
+/**
+ * This service initializes internal and external interfaces of the CAN
+ * interfaces for the further processing.
+ * @note This function takes a parameter in the AUTOSAR specs, but there
+ * is currently no parameter here because the function does nothing.
+ */
+void CanIf_Init(void);
+
+/**
+ * This service shall set the baud rate configuration of the CAN controller.
+ * Depending on necessary baud rate modifications the controller might have to
+ * reset.
+ *
+ * @param ControllerId Abstract CanIf ControllerId which is assigned to a CAN
+ * controller, whose baud rate shall be set.
+ * Here it is the index of the controller in the controllers list provided to
+ * Can_Init().
+ * @param BaudRateConfigID References a baud rate configuration by ID.
+ *
+ * @retval E_OK Service request accepted, setting of (new) baud rate started.
+ * @retval E_NOT_OK Service request not accepted.
+ */
+Std_ReturnType CanIf_SetBaudrate(uint8 ControllerId, uint16 BaudRateConfigID);
+
+/**
+ * Requests transmission of a PDU.
+ *
+ * @param TxPduId Identifier of the PDU to be transmitted.
+ * Here it is the index of the controller in the controllers list provided to
+ * Can_Init().
+ * @param PduInfoPtr Length of and pointer to the PDU data and pointer to
+ * MetaData.
+ *
+ * @retval E_OK Transmit request has been accepted.
+ * @retval E_NOT_OK Transmit request has not been accepted.
+ */
+Std_ReturnType CanIf_Transmit(PduIdType TxPduId, const PduInfoType *PduInfoPtr);
+
+/**
+ * This service provides the Data Length and the received data of the requested
+ * CanIfRxSduId to the calling upper layer.
+ *
+ * @param CanIfRxSduId Receive L-SDU handle specifying the corresponding CAN
+ * L-SDU ID and implicitly the CAN Driver instance as well as the corresponding
+ * CAN controller device.
+ * @param CanIfRxInfoPtr Contains the length (SduLength) of the received PDU,
+ * a pointer to a buffer (SduDataPtr) containing the PDU, and the MetaData
+ * related to this PDU.
+ *
+ * @retval E_OK Request for L-SDU data has been accepted.
+ * @retval E_NOT_OK No valid data has been received.
+ */
+Std_ReturnType CanIf_ReadRxPduData(PduIdType CanIfRxSduId, PduInfoType *CanIfRxInfoPtr);
+
+#endif

--- a/net/can/Can_GeneralTypes.h
+++ b/net/can/Can_GeneralTypes.h
@@ -1,0 +1,106 @@
+/**
+ * @file Can_GeneralTypes.h
+ *
+ * @section desc File description
+ *
+ * This implementation is based on AUTOSAR CAN Driver R22-11, see
+ * https://www.autosar.org/fileadmin/standards/R21-11/CP/AUTOSAR_SWS_CANDriver.pdf
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#ifndef CAN_GENERAL_TYPES_H
+#define CAN_GENERAL_TYPES_H
+
+#include <ComStack_Types.h>
+
+#define TPL_CAN_ID_TYPE_STANDARD (0x00 << 30)
+#define TPL_CAN_ID_TYPE_FD_STANDARD (0x01 << 30)
+#define TPL_CAN_ID_TYPE_EXTENDED (0x02 << 30)
+#define TPL_CAN_ID_TYPE_FD_EXTENDED (0x03 << 30)
+#define TPL_CAN_ID_TYPE_MASK (0x03 << 30)
+
+/**
+ * @note This will be replaced by a table provided to Can_Init() with
+ * several configurations mentionning both baud rates for CAN 2.0 and CAN FD.
+ */
+typedef enum
+{
+	CAN_BAUD_RATE_50_KBPS,
+	CAN_BAUD_RATE_100_KBPS,
+	CAN_BAUD_RATE_125_KBPS,
+	CAN_BAUD_RATE_250_KBPS,
+	CAN_BAUD_RATE_500_KBPS,
+	CAN_BAUD_RATE_1_MBPS,
+	CAN_BAUD_RATE_COUNT
+} tpl_can_baud_rate_t;
+
+/**
+ * @typedef Can_IdType
+ *
+ * Represents the identifier of an L-PDU. The two most significant bits specify
+ * the frame type:
+ * 00: CAN message with standard CAN ID,
+ * 01: CAN FD frame with standard CAN ID,
+ * 10: CAN message with extended CAN ID,
+ * 11: CAN FD frame with extended CAN ID.
+ *
+ * @see TPL_CAN_ID_TYPE_STANDARD and related constants to use for the frame
+ * type.
+ */
+typedef uint32 Can_IdType;
+
+/**
+ * @typedef Can_PduType
+ *
+ * This type unites PduId (swPduHandle), SduLength (length), SduData (sdu)
+ * and CanId (id) for any CAN L-SDU.
+ */
+typedef struct
+{
+	PduIdType swPduHandle;
+	uint8 length;
+	Can_IdType id;
+	uint8 *sdu;
+} Can_PduType;
+
+/**
+ * @struct tpl_can_controller_t
+ *
+ * Contains all details and callback functions to directly interact with a
+ * CAN controller hardware.
+ */
+struct tpl_can_controller_t
+{
+	uint32 base_address;
+	int (*init)(struct tpl_can_controller_t *ctrl, void *data);
+	int (*set_baudrate)(struct tpl_can_controller_t *ctrl, tpl_can_baud_rate_t baud_rate);
+	Std_ReturnType (*transmit)(struct tpl_can_controller_t *ctrl, const Can_PduType *pdu_info);
+	Std_ReturnType (*receive)(struct tpl_can_controller_t *ctrl, Can_PduType *pdu_info);
+	int (*is_data_available)(struct tpl_can_controller_t *ctrl);
+};
+typedef struct tpl_can_controller_t tpl_can_controller_t;
+
+/**
+ * @typedef Can_HwHandleType
+ *
+ * Represents the hardware object handles of a CAN hardware unit.
+ */
+typedef tpl_can_controller_t *Can_HwHandleType;
+
+#endif

--- a/net/can/tpl_can_core.c
+++ b/net/can/tpl_can_core.c
@@ -1,0 +1,135 @@
+/**
+ * @file tpl_can_core.c
+ *
+ * @section desc File description
+ *
+ * Implements the AUTOSAR CAN Driver and CAN Interface layers.
+ *
+ * @section copyright Copyright
+ *
+ * Trampoline OS
+ *
+ * Trampoline is copyright (c) IRCCyN 2005+
+ * Trampoline is protected by the French intellectual property law.
+ *
+ * (C) BayLibre 2023
+ *
+ * This software is distributed under the Lesser GNU Public Licence
+ *
+ *  @section infos File informations
+ *
+ *  $Date$
+ *  $Rev$
+ *  $Author$
+ *  $URL$
+ */
+#include <Can.h>
+#include <CanIf.h>
+#include <tpl_os_definitions.h>
+
+static tpl_can_controller_t **controllers_list;
+static int controllers_count;
+
+int Can_Init(const Can_ConfigType *Config)
+{
+	int i, ret;
+	tpl_can_controller_t **ctrl_list, *ctrl;
+
+	controllers_list = Config->controllers_list;
+	controllers_count = 0;
+	ctrl_list = controllers_list;
+	while ((ctrl = *ctrl_list) != NULL)
+	{
+		// Make sure all callback functions are provided (check only once here to avoid checking later at every function call)
+		if (!ctrl->init)
+			return -5;
+		if (!ctrl->set_baudrate)
+			return -5;
+		if (!ctrl->transmit)
+			return -5;
+		if (!ctrl->receive)
+			return -5;
+		if (!ctrl->is_data_available)
+			return -5;
+
+		ret = ctrl->init(ctrl, NULL);
+		if (ret)
+			return ret;
+
+		ctrl_list++;
+		controllers_count++;
+	}
+
+	return 0;
+}
+
+Std_ReturnType Can_SetBaudrate(uint8 Controller, uint16 BaudRateConfigID)
+{
+	tpl_can_controller_t *ctrl;
+
+	// Make sure the controller has been registered and initialized
+	if (Controller >= controllers_count)
+		return E_NOT_OK;
+	ctrl = controllers_list[Controller];
+
+	if (ctrl->set_baudrate(ctrl, BaudRateConfigID))
+		return E_NOT_OK;
+	return E_OK;
+}
+
+Std_ReturnType Can_Write(Can_HwHandleType Hth, const Can_PduType *PduInfo)
+{
+	tpl_can_controller_t *ctrl = Hth;
+	Std_ReturnType ret = E_NOT_OK;
+
+	if (ctrl == NULL)
+		return E_NOT_OK;
+
+	if (ctrl->transmit)
+		ret = ctrl->transmit(ctrl, PduInfo);
+
+	return ret;
+}
+
+void CanIf_Init(void)
+{
+	// TODO, maybe flags to enable CAN FD
+}
+
+Std_ReturnType CanIf_SetBaudrate(uint8 ControllerId, uint16 BaudRateConfigID)
+{
+	// The ControllerId checking will be done by Can_SetBaudrate(), so call
+	// this function directly
+	return Can_SetBaudrate(ControllerId, BaudRateConfigID);
+}
+
+Std_ReturnType CanIf_Transmit(PduIdType TxPduId, const PduInfoType *PduInfoPtr)
+{
+	tpl_can_controller_t *ctrl;
+	Can_PduType *can_pdu;
+
+	// Make sure the controller has been registered and initialized
+	if (TxPduId >= controllers_count)
+		return E_NOT_OK;
+	ctrl = controllers_list[TxPduId];
+
+	can_pdu = (Can_PduType *) PduInfoPtr->SduDataPtr;
+	return Can_Write(ctrl, can_pdu);
+}
+
+Std_ReturnType CanIf_ReadRxPduData(PduIdType CanIfRxSduId, PduInfoType *CanIfRxInfoPtr)
+{
+	tpl_can_controller_t *ctrl;
+	Can_PduType *can_pdu;
+
+	// Make sure the controller has been registered and initialized
+	if (CanIfRxSduId >= controllers_count)
+		return E_NOT_OK;
+	ctrl = controllers_list[CanIfRxSduId];
+
+	if (!ctrl->is_data_available(ctrl))
+		return E_NOT_OK;
+
+	can_pdu = (Can_PduType *) CanIfRxInfoPtr->SduDataPtr;
+	return ctrl->receive(ctrl, can_pdu);
+}

--- a/os/tpl_os_types.h
+++ b/os/tpl_os_types.h
@@ -33,6 +33,16 @@ typedef tpl_status      StatusType;
 #endif
 
 /**
+ * @typedef Std_ReturnType
+ *
+ * This type can be used as standard API return type which is shared between the
+ * RTE and the BSW modules.
+ *
+ * See AUTOSAR R21-11 AUTOSAR_SWS_StandardTypes chapter 8.1.1.
+ */
+typedef uint8 Std_ReturnType;
+
+/**
  * @typedef TaskStateType
  *
  * identifies the state of a task


### PR DESCRIPTION
This PR adds the CAN 2.0 stack, a dummy CAN driver for the POSIX machine and an example application.

The CAN stack is designed to be as close as possible to the AUTOSAR R22-11 specs, but also to stay minimal. Thus, only parts of the CAN Driver and CAN Interface specs have been implemented. All variations with the standards are documented in the code.

The dummy CAN driver and the example application allow to showcase the CAN stack on a development PC.

Feel free to comment and suggest changes !