### PR TITLE
making the idle function efficient by using WFE instead empty while

### DIFF
--- a/machines/cortex/tpl_machine_cortex.c
+++ b/machines/cortex/tpl_machine_cortex.c
@@ -289,7 +289,10 @@ FUNC(uint8, OS_CODE) tpl_check_stack_footprint(CONST(tpl_proc_id, OS_APPL_DATA) 
  */
 void idle_function(void)
 {
-    while(1);
+    while(1)
+  {
+      __WFE();
+  }
 }
 
 void tpl_init_machine()


### PR DESCRIPTION
there was a problem with the idle function entering empty while looping, which consumes the processor instead of being in sleep mode, I have edited it to make it wait for an event (WFE) which achieves the sleep mode and doesn't consume the processor.