### PR TITLE
machines: posix: Fixed OS base types size on 64-bit development systems.

### DIFF
--- a/machines/posix/tpl_os_std_types.h
+++ b/machines/posix/tpl_os_std_types.h
@@ -27,47 +27,49 @@
 #ifndef TPL_OS_STD_TYPES_H
 #define TPL_OS_STD_TYPES_H
 
+#include <stdint.h>
+
 /**
  * @typedef uint8
  *
  * 8 bits unsigned number
  */
-typedef unsigned char   uint8;
+typedef uint8_t uint8;
 
 /**
  * @typedef sint8
  *
  * 8 bits signed number
  */
-typedef signed char     sint8;
+typedef int8_t sint8;
 
 /**
  * @typedef uint16
  *
  * 16 bits unsigned number
  */
-typedef unsigned short  uint16;
+typedef uint16_t uint16;
 
 /**
  * @typedef sint16
  *
  * 16 bits signed number
  */
-typedef signed short    sint16;
+typedef int16_t sint16;
 
 /**
  * @typedef uint32
  *
  * 32 bits unsigned number
  */
-typedef unsigned long   uint32;
+typedef uint32_t uint32;
 
 /**
  * @typedef sint32
  *
  * 32 bits signed number
  */
-typedef signed long     sint32;
+typedef int32_t sint32;
 
 #endif /* TPL_OS_STD_TYPES_H */
 


### PR DESCRIPTION
On a 64-bit development machine, the C type 'int' size is 4 bytes, but the 'long' type size is 8 bytes.

This commit fixes the TrampolineOS POSIX machine 'uint32' and 'sint32' types that are 8-byte long when compiled on a x86_64 machine instead of being 4-byte long.