### PR TITLE
CI: Added Cortex-M and ViPER CI builds.

### DIFF
--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -239,3 +239,28 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/cortex/armv7em/stm32f303/Nucleo-32/${{ matrix.example_name }}
+
+  cortex-m-smart-stm32f4discovery-examples:
+    name: Build Cortex-M STM32F4DISCOVERY examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        # List only the examples that currently compile
+        example_name: [blink, readbutton, testDisableEnable]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv7em/stm32f407/stm32f4discovery --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv7em/stm32f407/stm32f4discovery/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv7em/stm32f407/stm32f4discovery/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -214,3 +214,28 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/cortex/armv7m/SmartFusion2/starterKit/${{ matrix.example_name }}
+
+  cortex-m-smart-nucleo-f303-examples:
+    name: Build Cortex-M Nucleo-F303 examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        # List only the examples that currently compile
+        example_name: [blink, serial]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv7em/stm32f303 --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv7em/stm32f303/Nucleo-32/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv7em/stm32f303/Nucleo-32/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -117,3 +117,27 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/posix/${{ matrix.example_name }}
+
+  cortex-m-arduino-m0-examples:
+    name: Build Cortex-M Arduino M0 examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        example_name: [blink]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv6m/samd21/ArduinoM0 --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv6m/samd21/ArduinoM0/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv6m/samd21/ArduinoM0/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -141,3 +141,27 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/cortex/armv6m/samd21/ArduinoM0/${{ matrix.example_name }}
+
+  cortex-m-xplained-pro-examples:
+    name: Build Cortex-M Xplained Pro examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        example_name: [blink, readbutton, readbutton_isr]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv6m/samd21/XPlainedPro --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv6m/samd21/XPlainedPro/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv6m/samd21/XPlainedPro/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -240,6 +240,31 @@ jobs:
         run: ./make.py
         working-directory: examples/cortex/armv7em/stm32f303/Nucleo-32/${{ matrix.example_name }}
 
+  cortex-m-smart-nucleo-l432-examples:
+    name: Build Cortex-M Nucleo-F432 examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        # List only the examples that currently compile
+        example_name: [blink, readbutton, serial]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv7em/stm32l432 --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv7em/stm32l432/Nucleo-32/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv7em/stm32l432/Nucleo-32/${{ matrix.example_name }}
+
   cortex-m-smart-stm32f4discovery-examples:
     name: Build Cortex-M STM32F4DISCOVERY examples
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -165,3 +165,27 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/cortex/armv6m/samd21/XPlainedPro/${{ matrix.example_name }}
+
+  cortex-m-arduino-due-examples:
+    name: Build Cortex-M Arduino Due examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        example_name: [blink]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv7m/atsam3x8e/arduino_due --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv7m/atsam3x8e/arduino_due/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv7m/atsam3x8e/arduino_due/${{ matrix.example_name }}

--- a/.github/workflows/build-examples.yaml
+++ b/.github/workflows/build-examples.yaml
@@ -189,3 +189,28 @@ jobs:
       - name: Build the code
         run: ./make.py
         working-directory: examples/cortex/armv7m/atsam3x8e/arduino_due/${{ matrix.example_name }}
+
+  cortex-m-smart-fusion-2-examples:
+    name: Build Cortex-M SmartFusion2 examples
+    runs-on: ubuntu-22.04
+    needs: goil
+    strategy:
+      matrix:
+        # List only the examples that currently compile
+        example_name: [blink]
+    steps:
+      - name: Install ARM toolchain
+        run: |
+          sudo apt update
+          sudo apt install -y gcc-arm-none-eabi
+      - name: Retrieve sources and Goil binary
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ github.workspace }}
+          key: ${{ env.CACHE_KEY }}
+      - name: Generate the code
+        run: ${{ env.GOIL }} --target=cortex/armv7m/SmartFusion2 --templates=../../../../../../goil/templates/ ${{ matrix.example_name }}.oil
+        working-directory: examples/cortex/armv7m/SmartFusion2/starterKit/${{ matrix.example_name }}
+      - name: Build the code
+        run: ./make.py
+        working-directory: examples/cortex/armv7m/SmartFusion2/starterKit/${{ matrix.example_name }}

--- a/.github/workflows/build-viper.yaml
+++ b/.github/workflows/build-viper.yaml
@@ -1,0 +1,15 @@
+name: Build ViPER (Virtual Processor EmulatoR)
+on: [push, pull_request]
+
+jobs:
+  viper:
+    name: Build ViPER
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Build
+        run: make
+        working-directory: viper


### PR DESCRIPTION
The Cortex-M CI will help during the `cortex` to `cortex-m` change to make sure all examples that were building before still build now (see issue https://github.com/TrampolineRTOS/trampoline/issues/138).

Also added the ViPER POSIX emulator build.