### PR TITLE
Spider: ethernet: fix ethernet issues and extend port usage

### DIFF
--- a/goil/templates/config/cortex-a-r/armv8/spider/buildOptions.oil
+++ b/goil/templates/config/cortex-a-r/armv8/spider/buildOptions.oil
@@ -9,7 +9,6 @@ CPU buildOptions {
      */
 //    COMMONFLAGS = "-g";                           // Produce debugging information
     COMMONFLAGS = "-Wall";                        // All warnings on
-    COMMONFLAGS = "-pedantic";
     COMMONFLAGS = "-Wformat";
     COMMONFLAGS = "-std=c99";
     COMMONFLAGS = "-mcpu=cortex-r52";              // Compile for arm r52

--- a/goil/templates/config/cortex-a-r/armv8/spider/config.oil
+++ b/goil/templates/config/cortex-a-r/armv8/spider/config.oil
@@ -56,6 +56,7 @@ CPU spider {
     CFILE = "tpl_stubs.c";
     CFILE = "tpl_irq.c";
     CFILE = "tpl_vector_table_ns.s";
+    CFILE = "spider_utils.c";
   };
 
   LIBRARY serial {

--- a/libraries/drivers/ethernet/renesas/eth_serdes.c
+++ b/libraries/drivers/ethernet/renesas/eth_serdes.c
@@ -86,7 +86,7 @@ static int eth_serdes_wait_reset(void)
 {
     int ch, ret;
 
-    for (ch = 0; ch < ETH_SERDES_CH_NUM; ch++) {
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
         ETH_SERDES_SEL_BANK(ch, 0x0180U);
         ret = eth_serdes_wait_for_update(ch, 0x026C, BIT(0), BIT(0), ETH_TIMEOUT_COUNT);
         if (ret != 0) {
@@ -105,8 +105,10 @@ static int eth_serdes_initialize_SRAM(void)
         return ret;
     }
 
-    ETH_SERDES_SEL_BANK(ETH_SERDES_XPCS_CH0, 0x0180);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x026C, 0x3);
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
+        ETH_SERDES_SEL_BANK(ch, 0x0180);
+        ETH_SERDES_REG_WRITE(ch, 0x026C, 0x3);
+    }
     
     for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
         ETH_SERDES_SEL_BANK(ch, 0x0300U);
@@ -121,22 +123,27 @@ static int eth_serdes_initialize_SRAM(void)
 
 static void eth_serdes_set_SGMII_common_settings(void)
 {
+    int ch;
     /* Steps S.4.1 to S.4.5 */
-    ETH_SERDES_SEL_BANK(ETH_SERDES_XPCS_CH0, 0x0180);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x0244, 0x97);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x01D0, 0x60);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x01D8, 0x2200);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x01D4, 0x0);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x01E0, 0x3D);
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
+        ETH_SERDES_SEL_BANK(ch, 0x0180);
+        ETH_SERDES_REG_WRITE(ch, 0x0244, 0x97);
+        ETH_SERDES_REG_WRITE(ch, 0x01D0, 0x60);
+        ETH_SERDES_REG_WRITE(ch, 0x01D8, 0x2200);
+        ETH_SERDES_REG_WRITE(ch, 0x01D4, 0x0);
+        ETH_SERDES_REG_WRITE(ch, 0x01E0, 0x3D);
+    }
 }
 
 static int eth_serdes_PHY_soft_reset(void)
 {
-    int ret;
+    int ch, ret;
 
     /* Step:5 */
-    ETH_SERDES_SEL_BANK(ETH_SERDES_XPCS_CH0, 0x0380);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x0000, 0x8000);
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
+        ETH_SERDES_SEL_BANK(ch, 0x0380);
+        ETH_SERDES_REG_WRITE(ch, 0x0000, 0x8000);
+    }
 
     /* Step:6 */
     ret = eth_serdes_wait_reset();
@@ -145,14 +152,21 @@ static int eth_serdes_PHY_soft_reset(void)
     }
 
     /* Step:7 */
-    ETH_SERDES_SEL_BANK(ETH_SERDES_XPCS_CH0, 0x0180U);
-    ETH_SERDES_REG_WRITE(ETH_SERDES_XPCS_CH0, 0x026CU, 0x00000003UL);
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
+        ETH_SERDES_SEL_BANK(ch, 0x0180U);
+        ETH_SERDES_REG_WRITE(ch, 0x026CU, 0x00000003UL);
+    }
 
     /* Step:8 */
-    ETH_SERDES_SEL_BANK(ETH_SERDES_XPCS_CH0, 0x0380U);
-    ret = eth_serdes_wait_for_update(ETH_SERDES_XPCS_CH0, 0x0000U, BIT(15), 0UL, ETH_TIMEOUT_COUNT);
+    for (ch = ETH_SERDES_XPCS_CH0; ch < ETH_SERDES_CH_NUM; ch++) {
+        ETH_SERDES_SEL_BANK(ch, 0x0380U);
+        ret = eth_serdes_wait_for_update(ch, 0x0000U, BIT(15), 0UL, ETH_TIMEOUT_COUNT);
+        if (ret != 0) {
+            return ret;
+        }
+    }
 
-    return ret;
+    return 0;
 }
 
 static int eth_serdes_channel_SGMII_common_configuration(uint32 ch)

--- a/libraries/drivers/ethernet/renesas/rswitch.c
+++ b/libraries/drivers/ethernet/renesas/rswitch.c
@@ -778,31 +778,31 @@ static int rswitch_phy_init(struct rswitch_etha *etha)
     int ret;
 
     /* Reset */
-    CHECK_RET(rswitch_mii_read(etha, 1, etha->port_num + 1, 0xC04A, &reg_data));
+    CHECK_RET(rswitch_mii_read(etha, etha->port_num + 1, 1, 0xC04A, &reg_data));
     reg_data |= BIT(15);
-    CHECK_RET(rswitch_mii_write(etha, 1, etha->port_num + 1, 0xC04A, &reg_data));
-    CHECK_RET(rswitch_mii_write(etha, 1, etha->port_num + 1, 0xC04A, &reg_data)); /* MCAL does it twice... */
+    CHECK_RET(rswitch_mii_write(etha, etha->port_num + 1, 1, 0xC04A, &reg_data));
+    CHECK_RET(rswitch_mii_write(etha, etha->port_num + 1, 1, 0xC04A, &reg_data)); /* MCAL does it twice... */
 
     /* Check mode */
-    CHECK_RET(rswitch_mii_read(etha, 1, etha->port_num + 1, 0xC04A, &reg_data));
+    CHECK_RET(rswitch_mii_read(etha, etha->port_num + 1, 1, 0xC04A, &reg_data));
     if ((reg_data & 0x7) != 0x4 ) { /* 4 stands for SGMII */
         reg_data &= ~0x7;
         reg_data |= BIT(15) | 0x4;
-        CHECK_RET(rswitch_mii_write(etha, 1, etha->port_num + 1, 0xC04A, &reg_data));
+        CHECK_RET(rswitch_mii_write(etha, etha->port_num + 1, 1, 0xC04A, &reg_data));
 
         /* Run SERDES Init */
-        CHECK_RET(rswitch_mii_read(etha, 1, etha->port_num + 1, 0x800F, &reg_data));
+        CHECK_RET(rswitch_mii_read(etha, etha->port_num + 1, 1, 0x800F, &reg_data));
         reg_data |= BIT(15) | BIT(13);
-        CHECK_RET(rswitch_mii_write(etha, 1, etha->port_num + 1, 0x800F, &reg_data));
+        CHECK_RET(rswitch_mii_write(etha, etha->port_num + 1, 1, 0x800F, &reg_data));
         
         reg_data = 0x0U;
         do {
-            CHECK_RET(rswitch_mii_read(etha, 1, etha->port_num + 1, 0x800F, &reg_data));
+            CHECK_RET(rswitch_mii_read(etha, etha->port_num + 1, 1, 0x800F, &reg_data));
         } while (reg_data & BIT(15));
 
         /* Auto SERDES Init Disable */
         reg_data &= ~BIT(13);
-        CHECK_RET(rswitch_mii_write(etha, 1, etha->port_num + 1, 0x800F, &reg_data));
+        CHECK_RET(rswitch_mii_write(etha, etha->port_num + 1, 1, 0x800F, &reg_data));
     }
 
     return 0;

--- a/libraries/drivers/ethernet/renesas/rswitch.c
+++ b/libraries/drivers/ethernet/renesas/rswitch.c
@@ -3,6 +3,7 @@
 #include "rswitch.h"
 #include "rswitch_regs.h"
 #include "err_codes.h"
+#include "spider_utils.h"
 #include <string.h>
 
 #define PORT_TSNA_N     3
@@ -929,6 +930,7 @@ TASK(gwca1_rx_tx_task) {
         if (chain->irq_triggered != 0) {
             /* Go through the descriptors chain to parse received data */
             while (1) {
+                invalidate_data_cache_by_address(rx_ring, sizeof(rx_ring));
                 ts_desc = &(chain->ts_ring[chain->next_index]);
                 /* Stop once we get to a descriptor that was not modified */
                 if (ts_desc->die_dt == (DT_FEMPTY | DIE)) {

--- a/machines/cortex-a-r/armv8/spider/spider_utils.c
+++ b/machines/cortex-a-r/armv8/spider/spider_utils.c
@@ -1,0 +1,22 @@
+#include "emblib.h"
+
+#define DCACHE_LINE_SIZE      64
+
+void invalidate_data_cache_by_address(volatile void *addr, sint32 dsize)
+{
+    if ( dsize > 0 ) {
+        sint32 op_size = dsize + (((uint32)addr) & (DCACHE_LINE_SIZE - 1U));
+        uint32 op_addr = (uint32)addr;
+
+        __asm__ volatile ("dsb");
+
+        do {
+            cp15_write32(0, 7, 6, 1, op_addr);
+            op_addr += DCACHE_LINE_SIZE;
+            op_size -= DCACHE_LINE_SIZE;
+        } while ( op_size > 0 );
+
+        __asm__ volatile ("dsb");
+        __asm__ volatile ("isb");
+    }
+}

--- a/machines/cortex-a-r/armv8/spider/spider_utils.h
+++ b/machines/cortex-a-r/armv8/spider/spider_utils.h
@@ -1,0 +1,3 @@
+
+
+void invalidate_data_cache_by_address(volatile void *addr, sint32 dsize);


### PR DESCRIPTION
This PR resolves 2 issues:

1. It gives the user the possibility to select any TSN port between TSN0, TSN1 or TSN2 for Ethernet communication. 
    - Previously this was supposed to work, but actually there were some parts for the initialization code which was hard-coded to TSN0, so not properly configuring TSN1/TSN2
    - Selection of the desired port should still be done at build time. There is no support for auto detection of the active one at runtime

2. It solves an issue with `L1 cache<->RAM` alignement which can prevent the ethernet driver and examples to work properly