### PR TITLE
G4mh add serial/printf support and fix a context switch issue

### DIFF
--- a/examples/rh850/serial/build.sh
+++ b/examples/rh850/serial/build.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+#stop on errors
+set -e
+
+if [[ ! -d "_build" ]]
+then
+    mkdir _build
+fi
+
+echo "*** Run Goil ***"
+goil --target=rh850/g4mh --templates=../../../goil/templates/ serial.oil
+cd _build
+echo "*** Run CMake ***"
+cmake -G "Unix Makefiles" -D CMAKE_TOOLCHAIN_FILE=../serial/compiler.cmake ..
+echo "*** Run Make ***"
+make

--- a/examples/rh850/serial/serial.c
+++ b/examples/rh850/serial/serial.c
@@ -1,0 +1,39 @@
+#include "tpl_os.h"
+
+#include "spider_serial.h"
+#include "printf.h"
+
+FUNC(int, OS_APPL_CODE) main(void)
+{
+
+	StartOS(OSDEFAULTAPPMODE);
+	return 0;
+}
+
+volatile uint32 tmp = 0;
+
+TASK(serial_rx)
+{
+	uint8 uart_rx;
+
+	Serial_Init();
+
+	debug_printf("serial_rx task started\r\n");
+
+	while(1)
+	{
+		if (Serial_Rx(&uart_rx))
+		{
+			/* If received a char, send back the next one */
+			Serial_Tx(uart_rx+1);
+		}
+	}
+}
+
+TASK(serial_tx)
+{
+	/* Send next alphabet letter each time*/
+	static uint8 uart_char=0;
+	uart_char = (uart_char+1) % 26;
+	Serial_Tx('a' + uart_char);
+}

--- a/examples/rh850/serial/serial.oil
+++ b/examples/rh850/serial/serial.oil
@@ -1,0 +1,59 @@
+OIL_VERSION = "4.2";
+
+IMPLEMENTATION trampoline {
+  TASK {
+    UINT32 STACKSIZE = 2048 ;
+  } ;
+
+  ISR {
+    UINT32 STACKSIZE = 2048 ;
+  } ;
+};
+
+CPU serial {
+  OS config {
+    STATUS = EXTENDED;
+
+    BUILD = TRUE {
+      TRAMPOLINE_BASE_PATH = "../../../";
+      APP_SRC = "serial.c";
+      APP_NAME = "serial_exe";
+      LDFLAGS="-debug -nocompress -NOOPtimize -memory=high -nologo -SHow=ALL";
+      CFLAGS="-DHSCIF_1843200BPS -Xcpu=g4mh -g -g_line -Xfxu=off -Xasm_path=.";
+      LINKER = "rlink";
+      SYSTEM = CMAKE;
+
+      LIBRARY = serial;
+    };
+    SYSTEM_CALL = TRUE;
+  };
+
+  APPMODE std {};
+
+  TASK serial_rx { 
+    PRIORITY = 1;
+    AUTOSTART = TRUE { APPMODE = std; };
+    ACTIVATION = 1;
+    SCHEDULE = FULL;
+  };
+
+  TASK serial_tx {
+    PRIORITY = 2;
+    AUTOSTART = FALSE;
+    ACTIVATION = 1;
+    SCHEDULE = FULL;
+  };
+
+  ALARM serial_serial {
+    COUNTER = SystemCounter;
+    ACTION = ACTIVATETASK {
+      TASK = serial_tx;
+    };
+    AUTOSTART = TRUE {
+      APPMODE = std;
+      ALARMTIME = 100;
+      CYCLETIME = 100;
+    };
+  };
+};
+

--- a/goil/templates/config/rh850/g4mh/config.oil
+++ b/goil/templates/config/rh850/g4mh/config.oil
@@ -9,6 +9,11 @@ CPU renesas {
     NEEDS = net_can_renesas_spider_driver;
     PATH = "net/can";
   };
+
+  LIBRARY serial {
+    GLOBAL = TRUE;
+    PATH = "drivers/serial/renesas";
+  };
 };
 
 IMPLEMENTATION renesas {
@@ -16,7 +21,8 @@ IMPLEMENTATION renesas {
     BOOLEAN [
       TRUE {
         ENUM [
-          can
+          can,
+          serial
         ] LIBRARY[];
       },
       FALSE

--- a/libraries/drivers/serial/renesas/spider_serial.h
+++ b/libraries/drivers/serial/renesas/spider_serial.h
@@ -3,11 +3,17 @@
 
 #include "tpl_os.h"
 
+#if __arm__
 /* SCIF3 */
 #define SCIF_BASE_ADDR                      0xE6C50000
-
 /* HSCIF0 */
 #define HSCIF_BASE_ADDR                     0xE6540000
+#else
+/* SCIF3 */
+#define SCIF_BASE_ADDR                      0xD6C50000
+/* HSCIF0 */
+#define HSCIF_BASE_ADDR                     0xD6540000
+#endif
 
 /* BRR computing:
  *   HSBRR: Register value = Internal clock / ( Sr * 2^(2*n + 1) * B) * 10^6 -1

--- a/machines/rh850/tpl_irq_handler.asm
+++ b/machines/rh850/tpl_irq_handler.asm
@@ -65,11 +65,11 @@ __irq_handler:
 	pushsp r21, r31
 
 	; Save the current context.
-	mov TPL_KERN_OFFSET_S_RUNNING, r10
-	movhi HIGHW1(#_tpl_kern), r10, r11 ; get pointer to the descriptor of the running task
-	ld.w LOWW(#_tpl_kern)[r11], r10
-
-	st.w r3, [r10] ; save running task sp
+	mov #_tpl_kern, r10
+	addi TPL_KERN_OFFSET_S_RUNNING, r10, r11 ; get pointer to the descriptor of the running task
+	ld.w [r11], r10 ; get pointer to the running task context
+	ld.w [r10], r11
+	st.w r3, [r11] ; save running task sp
 
 	; Switch back to kernel stack
 	mov r4, r3
@@ -79,12 +79,11 @@ __irq_handler:
 	jarl _tpl_run_elected, r31
 
 	; Update the current context according to SP given by the OS
-	mov TPL_KERN_OFFSET_S_RUNNING, r10
-	movhi HIGHW1(#_tpl_kern), r10, r11 ; Get pointer to the descriptor of the new running task
-	ld.w LOWW(#_tpl_kern)[r11], r10
-
-	ld.w [r10], r11 ; Get SP of elected task
-	ld.w [r11], r3
+	mov #_tpl_kern, r10
+	addi TPL_KERN_OFFSET_S_RUNNING, r10, r11 ; get pointer to the descriptor of the running task
+	ld.w [r11], r10 ; Get SP of elected task
+	ld.w [r10], r11
+	ld.w [r11], r3 ; load running task sp
 
 	; epilogue
 	popsp r21, r31

--- a/machines/rh850/tpl_machine_renesas.c
+++ b/machines/rh850/tpl_machine_renesas.c
@@ -2,13 +2,13 @@
 #include "tpl_machine.h"
 #include "tpl_machine_interface.h"
 #include "tpl_dispatch_table.h"
-#include "iodefine.h" //FSY: usefull?
+#include "iodefine.h"
 
 VAR (tpl_context, OS_VAR) idle_task_context;
 
 VAR(tpl_stack_word, OS_VAR) idle_stack[IDLE_STACK_SIZE/sizeof(tpl_stack_word)];
 
-#define SYSTICK_HZ		((u32) 80000000) /* 80MHz : is it the correct frequency? */
+#define SYSTICK_HZ		((u32) 80000000) /* 80MHz */
 #define TICKS_FOR_10MS	SYSTICK_HZ / 100
 
 static void stop_systick()
@@ -170,9 +170,17 @@ extern u32 _tpl_syscall_table;
 
 FUNC(void, OS_CODE) tpl_init_machine(void)
 {
+	volatile uint32 val = 0;
+
 	/* Initialize Syscall registers */
 	__ldsr_rh(11, 1, SYSCALL_COUNT); /* SCCFG */
 	__ldsr_rh(12, 1, (u32) &_tpl_syscall_table); /* SCBP */
 
 	init_systick();
+
+	/* Enable access to the bus */
+	MCCR_SELB1.STBY_CTRL.UINT32 = 0x00000001;
+	do {
+		val = MCCR_SELB1.STBY_CTRL.UINT32;
+	} while (val != 0x00000001);
 }


### PR DESCRIPTION
Add serial/printf support for g4mh based on the common driver used also by cr52 on spider board
Fix a context switch issue: During the IRQ context switch the SP of the calling task was not correctly updated in the kernel structures.