### PR TITLE
goil: code: armv8: Fix ISR id mismatch

### DIFF
--- a/goil/templates/code/cortex-a-r/armv8/interrupt_table.goilTemplate
+++ b/goil/templates/code/cortex-a-r/armv8/interrupt_table.goilTemplate
@@ -88,7 +88,6 @@ foreach objList in objForSRC do
 FUNC(void, OS_CODE) % !objList_KEY %_Handler(void)
 {
 %
-  let indexISR2 := 0
   foreach obj in objList do
     if obj::KIND == "ISR" then
 # ISR 1
@@ -100,9 +99,8 @@ FUNC(void, OS_CODE) % !objList_KEY %_Handler(void)
         if obj::CATEGORY == 2 then
 # ISR2
 %
-  tpl_central_interrupt_handler(% !([TASKS length] + indexISR2) %);
+  tpl_central_interrupt_handler(% !obj::NAME %_id);
 %
-          let indexISR2 := indexISR2 + 1
         else
           error obj::CATEGORY : "This interrupt category ".obj::CATEGORY." does not exist"
         end if


### PR DESCRIPTION
Currently, interrupt handler has same id so that interrupt doesn't work correctly on envrionment which has multiple ISR.
This is caused by the scope of indexISR2 variable.

And, even if this issue is fixed, function order and index is not matched always because function order is change by priotiry. So, non-expected function may be called.

Thus, this patch fixes to use defined variable instead of index.

---

I tested by using Whitebox SDK v5.x-dev branch which contains following patch.
https://github.com/renesas-rcar/whitebox-sdk/commit/4b2d930953f8fa3ec42e834d1705c6bf6750c17d

Log without patch:
```
-> % grep tpl_central_interrupt_handler examples/cortex-a-r/armv8/spider/sample/sample/*
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(5);
```

Log with patch:
```
-> % grep tpl_central_interrupt_handler examples/cortex-a-r/armv8/spider/sample/sample/*
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(coma_err_int_id);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(etha1_err_int_id);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(gwca0_err_int_id);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(gwca0_rx_ts_int_id);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(gwca0_rx_tx_int_id);
examples/cortex-a-r/armv8/spider/sample/sample/tpl_app_config.c:  tpl_central_interrupt_handler(iccomInt_id);
```